### PR TITLE
Switch to SendGrid API key from username/password

### DIFF
--- a/.openshift/config/wp-config.php
+++ b/.openshift/config/wp-config.php
@@ -28,8 +28,7 @@
 /**
  * Code provided for users following SendGrid instructions linked above.
  */
-//define('SENDGRID_USERNAME', getenv('SENDGRID_USERNAME'));
-//define('SENDGRID_PASSWORD', getenv('SENDGRID_PASSWORD'));
+//define('SENDGRID_API_KEY', getenv('SENDGRID_API_KEY'));
 //define('SENDGRID_SEND_METHOD', 'api');
 
 /*


### PR DESCRIPTION
Better to use an API key with the correct permissions than username/password for this.

https://sendgrid.com/docs/Integrate/Tutorials/WordPress/wordpress_integration_faq.html#-What-permissions-should-my-API-keys-have

Looks like the OpenShift documentation could be updated too:

https://developers.openshift.com/external-services/sendgrid.html#php-wordpress